### PR TITLE
Change: Remove `v` prefix from docker tags

### DIFF
--- a/.github/workflows/ci-master-pr.yml
+++ b/.github/workflows/ci-master-pr.yml
@@ -79,7 +79,7 @@ jobs:
 
     # This step generates the docker tags
     - name: Prepare
-      id: prep-v1-3
+      id: prep-1-3
       run: |
         set -e
 
@@ -92,7 +92,7 @@ jobs:
         # Generate docker image tags
         # E.g. 'v0.0.0-<variant>' and 'v0.0.0-abc0123-<variant>'
         # E.g. 'master-<variant>' and 'master-abc0123-<variant>'
-        VARIANT="v1.3"
+        VARIANT="1.3"
         REF_VARIANT="${REF}-${VARIANT}"
         REF_SHA_VARIANT="${REF}-${SHA}-${VARIANT}"
 
@@ -102,45 +102,45 @@ jobs:
         echo "REF_VARIANT=$REF_VARIANT" >> $GITHUB_OUTPUT
         echo "REF_SHA_VARIANT=$REF_SHA_VARIANT" >> $GITHUB_OUTPUT
 
-    - name: v1.3 - Build (PRs)
+    - name: 1.3 - Build (PRs)
       # Run only on pull requests
       if: github.event_name == 'pull_request'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3
+        context: variants/1.3
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: false
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.3 - Build and push (master)
+    - name: 1.3 - Build and push (master)
       # Run only on master
       if: github.ref == 'refs/heads/master'
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3
+        context: variants/1.3
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3.outputs.REF_SHA_VARIANT }}
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
-    - name: v1.3 - Build and push (release)
+    - name: 1.3 - Build and push (release)
       if: startsWith(github.ref, 'refs/tags/')
       uses: docker/build-push-action@v3
       with:
-        context: variants/v1.3
+        context: variants/1.3
         platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x
         push: true
         tags: |
-          ${{ github.repository }}:${{ steps.prep-v1-3.outputs.VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3.outputs.REF_VARIANT }}
-          ${{ github.repository }}:${{ steps.prep-v1-3.outputs.REF_SHA_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3.outputs.VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3.outputs.REF_VARIANT }}
+          ${{ github.repository }}:${{ steps.prep-1-3.outputs.REF_SHA_VARIANT }}
           ${{ github.repository }}:latest
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A dockerfile for the LDAP ToolBox (LTB) Self Service Password utility, which is 
 
 | Tag | Dockerfile Build Context |
 |:-------:|:---------:|
-| `:v1.3`, `:latest` | [View](variants/v1.3) |
+| `:1.3`, `:latest` | [View](variants/1.3) |
 
 ## Deprecation notice
 

--- a/Update-Versions.ps1
+++ b/Update-Versions.ps1
@@ -1,0 +1,55 @@
+# This script is to update versions in versions.json, create PR(s) for each bumped version, merge PRs, and release
+# It may be run manually or as a cron
+# Use -WhatIf for dry run
+[CmdletBinding(SupportsShouldProcess)]
+param (
+    [Parameter(HelpMessage="Whether to clone a temporary repo before opening PRs. Useful in development")]
+    [switch]$CloneTempRepo
+,
+    [Parameter(HelpMessage="Whether to open a PR for each updated version in version.json")]
+    [switch]$PR
+,
+    [Parameter(HelpMessage="Whether to merge each PR one after another (note that this is not GitHub merge queue which cannot handle merge conflicts). The queue ensures each PR is rebased to prevent merge conflicts")]
+    [switch]$AutoMergeQueue
+,
+    [Parameter(HelpMessage="Whether to create a tagged release and closing milestone, after merging all PRs")]
+    [switch]$AutoRelease
+,
+    [Parameter(HelpMessage="-AutoRelease tag convention")]
+    [ValidateSet('calver', 'semver')]
+    [string]$AutoReleaseTagConvention = 'calver'
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Install modules
+@(
+    'Generate-DockerImageVariantsHelpers'
+    'Powershell-Yaml'
+) | % {
+    if (! (Get-InstalledModule $_ -ErrorAction SilentlyContinue) ) {
+        Install-Module $_ -Scope CurrentUser -Force
+    }
+}
+# Override with development module if it exists
+if (Test-Path ../Generate-DockerImageVariantsHelpers/src/Generate-DockerImageVariantsHelpers) {
+    Import-module ../Generate-DockerImageVariantsHelpers/src/Generate-DockerImageVariantsHelpers -Force
+}
+
+try {
+    if ($CloneTempRepo) {
+        $repo = Clone-TempRepo
+        Push-Location $repo
+    }
+
+    # Update versions.json, and open PRs with CI disabled
+    $prs = Update-DockerImageVariantsVersions -CommitPreScriptblock { Move-Item .github .github.disabled -Force } -PR:$PR -WhatIf:$WhatIfPreference
+    # Update versions.json, update PRs with CI, merge PRs one at a time, release and close milestone
+    $return = Update-DockerImageVariantsVersions -PR:$PR -AutoMergeQueue:$AutoMergeQueue -AutoRelease:$AutoRelease -AutoReleaseTagConvention $AutoReleaseTagConvention -WhatIf:$WhatIfPreference
+}catch {
+    throw
+}finally {
+    if ($CloneTempRepo) {
+        Pop-Location
+    }
+}

--- a/generate/definitions/VARIANTS.ps1
+++ b/generate/definitions/VARIANTS.ps1
@@ -9,7 +9,7 @@ $VARIANTS = @(
                 platforms = 'linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x'
                 job_group_key = $v
             }
-            tag = "v$v"
+            tag = $v
             tag_as_latest = if ($v -eq $local:VERSIONS[0] ) { $true } else { $false }
         }
     }

--- a/variants/1.3/Dockerfile
+++ b/variants/1.3/Dockerfile
@@ -1,0 +1,32 @@
+# Use this container to download the .deb because the SSL certs are expired in phusion/baseimage:0.9.16
+FROM alpine:3.14 AS build
+RUN wget -q https://ltb-project.org/archives/self-service-password_1.3-1_all.deb -O /self-service-password.deb
+
+FROM phusion/baseimage:0.9.16 AS final
+
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Install Apache2, PHP and LTB ssp
+RUN apt-get update && apt-get install -y ca-certificates apache2 php5 php5-mcrypt php5-ldap && apt-get clean
+COPY --from=build /self-service-password.deb .
+RUN dpkg -i self-service-password.deb ; rm -f self-service-password.deb
+
+# Log to stdout
+RUN sed -i 's#/var/log/apache2/ssp_error.log#/dev/stdout#g' `dpkg -L self-service-password | grep -w 'self-service-password\.conf'` \
+    && sed -i 's#/var/log/apache2/ssp_access.log#/dev/stdout#g' `dpkg -L self-service-password | grep -w 'self-service-password\.conf'`
+
+# Configure self-service-password site
+RUN ln -s ../../mods-available/mcrypt.ini /etc/php5/apache2/conf.d/20-mcrypt.ini
+RUN a2dissite 000-default && a2ensite self-service-password
+
+# This is where configuration goes
+ADD assets/config.inc.php /usr/share/self-service-password/conf/config.inc.php
+
+# Start Apache2 as runit service
+RUN mkdir /etc/service/apache2
+ADD assets/apache2.sh /etc/service/apache2/run
+
+EXPOSE 80

--- a/variants/1.3/assets/apache2.sh
+++ b/variants/1.3/assets/apache2.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec /usr/sbin/apache2ctl -DFOREGROUND -k start
+

--- a/variants/1.3/assets/config.inc.php
+++ b/variants/1.3/assets/config.inc.php
@@ -1,0 +1,310 @@
+<?php
+#==============================================================================
+# LTB Self Service Password
+#
+# Copyright (C) 2009 Clement OUDOT
+# Copyright (C) 2009 LTB-project.org
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# GPL License: http://www.gnu.org/licenses/gpl.txt
+#
+#==============================================================================
+
+#==============================================================================
+# All the default values are kept here, you should not modify it but use
+# config.inc.local.php file instead to override the settings from here.
+#==============================================================================
+
+#==============================================================================
+# Configuration
+#==============================================================================
+
+# Debug mode
+# true: log and display any errors or warnings (use this in configuration/testing)
+# false: log only errors and do not display them (use this in production)
+$debug = false;
+
+# LDAP
+$ldap_url = "ldap://localhost";
+$ldap_starttls = false;
+$ldap_binddn = "cn=manager,dc=example,dc=com";
+$ldap_bindpw = "secret";
+$ldap_base = "dc=example,dc=com";
+$ldap_login_attribute = "uid";
+$ldap_fullname_attribute = "cn";
+$ldap_filter = "(&(objectClass=person)($ldap_login_attribute={login}))";
+
+# Active Directory mode
+# true: use unicodePwd as password field
+# false: LDAPv3 standard behavior
+$ad_mode = false;
+# Force account unlock when password is changed
+$ad_options['force_unlock'] = false;
+# Force user change password at next login
+$ad_options['force_pwd_change'] = false;
+# Allow user with expired password to change password
+$ad_options['change_expired_password'] = false;
+
+# Samba mode
+# true: update sambaNTpassword and sambaPwdLastSet attributes too
+# false: just update the password
+$samba_mode = false;
+# Set password min/max age in Samba attributes
+#$samba_options['min_age'] = 5;
+#$samba_options['max_age'] = 45;
+
+# Shadow options - require shadowAccount objectClass
+# Update shadowLastChange
+$shadow_options['update_shadowLastChange'] = false;
+$shadow_options['update_shadowExpire'] = false;
+
+# Default to -1, never expire
+$shadow_options['shadow_expire_days'] = -1;
+
+# Hash mechanism for password:
+# SSHA, SSHA256, SSHA384, SSHA512
+# SHA, SHA256, SHA384, SHA512
+# SMD5
+# MD5
+# CRYPT
+# clear (the default)
+# auto (will check the hash of current password)
+# This option is not used with ad_mode = true
+$hash = "clear";
+
+# Prefix to use for salt with CRYPT
+$hash_options['crypt_salt_prefix'] = "$6$";
+$hash_options['crypt_salt_length'] = "6";
+
+# Local password policy
+# This is applied before directory password policy
+# Minimal length
+$pwd_min_length = 0;
+# Maximal length
+$pwd_max_length = 0;
+# Minimal lower characters
+$pwd_min_lower = 0;
+# Minimal upper characters
+$pwd_min_upper = 0;
+# Minimal digit characters
+$pwd_min_digit = 0;
+# Minimal special characters
+$pwd_min_special = 0;
+# Definition of special characters
+$pwd_special_chars = "^a-zA-Z0-9";
+# Forbidden characters
+#$pwd_forbidden_chars = "@%";
+# Don't reuse the same password as currently
+$pwd_no_reuse = true;
+# Check that password is different than login
+$pwd_diff_login = true;
+# Complexity: number of different class of character required
+$pwd_complexity = 0;
+# use pwnedpasswords api v2 to securely check if the password has been on a leak
+$use_pwnedpasswords = false;
+# Show policy constraints message:
+# always
+# never
+# onerror
+$pwd_show_policy = "never";
+# Position of password policy constraints message:
+# above - the form
+# below - the form
+$pwd_show_policy_pos = "above";
+
+# Who changes the password?
+# Also applicable for question/answer save
+# user: the user itself
+# manager: the above binddn
+$who_change_password = "user";
+
+## Standard change
+# Use standard change form?
+$use_change = true;
+
+## SSH Key Change
+# Allow changing of sshPublicKey?
+$change_sshkey = false;
+
+# What attribute should be changed by the changesshkey action?
+$change_sshkey_attribute = "sshPublicKey";
+
+# Who changes the sshPublicKey attribute?
+# Also applicable for question/answer save
+# user: the user itself
+# manager: the above binddn
+$who_change_sshkey = "user";
+
+# Notify users anytime their sshPublicKey is changed
+## Requires mail configuration below
+$notify_on_sshkey_change = false;
+
+## Questions/answers
+# Use questions/answers?
+# true (default)
+# false
+$use_questions = true;
+
+# Answer attribute should be hidden to users!
+$answer_objectClass = "extensibleObject";
+$answer_attribute = "info";
+
+# Crypt answers inside the directory
+$crypt_answers = true;
+
+# Extra questions (built-in questions are in lang/$lang.inc.php)
+#$messages['questions']['ice'] = "What is your favorite ice cream flavor?";
+
+## Token
+# Use tokens?
+# true (default)
+# false
+$use_tokens = true;
+# Crypt tokens?
+# true (default)
+# false
+$crypt_tokens = true;
+# Token lifetime in seconds
+$token_lifetime = "3600";
+
+## Mail
+# LDAP mail attribute
+$mail_attribute = "mail";
+# Get mail address directly from LDAP (only first mail entry)
+# and hide mail input field
+# default = false
+$mail_address_use_ldap = false;
+# Who the email should come from
+$mail_from = "admin@example.com";
+$mail_from_name = "Self Service Password";
+$mail_signature = "";
+# Notify users anytime their password is changed
+$notify_on_change = false;
+# PHPMailer configuration (see https://github.com/PHPMailer/PHPMailer)
+$mail_sendmailpath = '/usr/sbin/sendmail';
+$mail_protocol = 'smtp';
+$mail_smtp_debug = 0;
+$mail_debug_format = 'error_log';
+$mail_smtp_host = 'localhost';
+$mail_smtp_auth = false;
+$mail_smtp_user = '';
+$mail_smtp_pass = '';
+$mail_smtp_port = 25;
+$mail_smtp_timeout = 30;
+$mail_smtp_keepalive = false;
+$mail_smtp_secure = 'tls';
+$mail_smtp_autotls = true;
+$mail_contenttype = 'text/plain';
+$mail_wordwrap = 0;
+$mail_charset = 'utf-8';
+$mail_priority = 3;
+$mail_newline = PHP_EOL;
+
+## SMS
+# Use sms
+$use_sms = true;
+# SMS method (mail, api)
+$sms_method = "mail";
+$sms_api_lib = "lib/smsapi.inc.php";
+# GSM number attribute
+$sms_attribute = "mobile";
+# Partially hide number
+$sms_partially_hide_number = true;
+# Send SMS mail to address
+$smsmailto = "{sms_attribute}@service.provider.com";
+# Subject when sending email to SMTP to SMS provider
+$smsmail_subject = "Provider code";
+# Message
+$sms_message = "{smsresetmessage} {smstoken}";
+# Remove non digit characters from GSM number
+$sms_sanitize_number = false;
+# Truncate GSM number
+$sms_truncate_number = false;
+$sms_truncate_number_length = 10;
+# SMS token length
+$sms_token_length = 6;
+# Max attempts allowed for SMS token
+$max_attempts = 3;
+
+# Encryption, decryption keyphrase, required if $crypt_tokens = true
+# Please change it to anything long, random and complicated, you do not have to remember it
+# Changing it will also invalidate all previous tokens and SMS codes
+$keyphrase = "secret";
+
+# Reset URL (if behind a reverse proxy)
+#$reset_url = $_SERVER['HTTP_X_FORWARDED_PROTO'] . "://" . $_SERVER['HTTP_X_FORWARDED_HOST'] . $_SERVER['SCRIPT_NAME'];
+
+# Display help messages
+$show_help = true;
+
+# Default language
+$lang = "en";
+
+# List of authorized languages. If empty, all language are allowed.
+# If not empty and the user's browser language setting is not in that list, language from $lang will be used.
+$allowed_lang = array();
+
+# Display menu on top
+$show_menu = true;
+
+# Logo
+$logo = "images/ltb-logo.png";
+
+# Background image
+$background_image = "images/unsplash-space.jpeg";
+
+# Where to log password resets - Make sure apache has write permission
+# By default, they are logged in Apache log
+#$reset_request_log = "/var/log/self-service-password";
+
+# Invalid characters in login
+# Set at least "*()&|" to prevent LDAP injection
+# If empty, only alphanumeric characters are accepted
+$login_forbidden_chars = "*()&|";
+
+## CAPTCHA
+# Use Google reCAPTCHA (http://www.google.com/recaptcha)
+$use_recaptcha = false;
+# Go on the site to get public and private key
+$recaptcha_publickey = "";
+$recaptcha_privatekey = "";
+# Customization (see https://developers.google.com/recaptcha/docs/display)
+$recaptcha_theme = "light";
+$recaptcha_type = "image";
+$recaptcha_size = "normal";
+# reCAPTCHA request method, null for default, Fully Qualified Class Name to override
+# Useful when allow_url_fopen=0 ex. $recaptcha_request_method = '\ReCaptcha\RequestMethod\CurlPost';
+$recaptcha_request_method = null;
+
+## Default action
+# change
+# sendtoken
+# sendsms
+$default_action = "change";
+
+## Extra messages
+# They can also be defined in lang/ files
+#$messages['passwordchangedextramessage'] = NULL;
+#$messages['changehelpextramessage'] = NULL;
+
+# Launch a posthook script after successful password change
+#$posthook = "/usr/share/self-service-password/posthook.sh";
+#$display_posthook_error = true;
+
+# Hide some messages to not disclose sensitive information
+# These messages will be replaced by badcredentials error
+#$obscure_failure_messages = array("mailnomatch");
+
+# Allow to override current settings with local configuration
+if (file_exists (__DIR__ . '/config.inc.local.php')) {
+    require __DIR__ . '/config.inc.local.php';
+}


### PR DESCRIPTION
Docker image tag conventions are starting to become clear that it is preferred to omit `v` prefix. While having the `v` prefix in the past might have been common, it is becoming less and less common today, with most of docker official images
(https://github.com/docker-library/official-images) omitting the `v` prefix.
